### PR TITLE
Add patch for numpy 1.14.0 test to fix 6.10.2 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,24 +39,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256sum }}
   patches:
-    - 0001-Fix-tests-for-numpy-1.14.0.patch
+    - patches/0001-Fix-tests-for-numpy-1.14.0.patch
 
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,9 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256sum }}
+  patches:
+    - 0001-Fix-tests-for-numpy-1.14.0.patch
+
 
 build:
   number: 0
@@ -18,8 +21,6 @@ build:
   features:
     - vc9   # [win and py27]
     - vc14  # [win and py>=35]
-  patches:
-    - 0001-Fix-tests-for-numpy-1.14.0.patch
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ build:
   features:
     - vc9   # [win and py27]
     - vc14  # [win and py>=35]
+  patches:
+    - 0001-Fix-tests-for-numpy-1.14.0.patch
 
 requirements:
   build:

--- a/recipe/patches/0001-Fix-tests-for-numpy-1.14.0.patch
+++ b/recipe/patches/0001-Fix-tests-for-numpy-1.14.0.patch
@@ -1,0 +1,36 @@
+From 403c31383154befe58ece111755b5e4839a7738f Mon Sep 17 00:00:00 2001
+From: Matthew Honnibal <honnibal+gh@gmail.com>
+Date: Wed, 31 Jan 2018 20:18:35 +0100
+Subject: [PATCH] Fix tests for numpy 1.14.0
+
+---
+ thinc/tests/unit/test_affine.py | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/thinc/tests/unit/test_affine.py b/thinc/tests/unit/test_affine.py
+index 4b69d16..691990e 100644
+--- a/thinc/tests/unit/test_affine.py
++++ b/thinc/tests/unit/test_affine.py
+@@ -138,7 +138,8 @@ def test_predict_small(W_b_input):
+     model.b[:] = b
+ 
+     einsummed = numpy.einsum('oi,bi->bo', numpy.asarray(W, dtype='float64'),
+-                            numpy.asarray(input_, dtype='float64'))
++                            numpy.asarray(input_, dtype='float64'),
++                            optimize=False)
+     
+     expected_output = einsummed + b
+     
+@@ -155,7 +156,8 @@ def test_predict_extensive(W_b_input):
+     model.b[:] = b
+ 
+     einsummed = numpy.einsum('oi,bi->bo', numpy.asarray(W, dtype='float64'),
+-                            numpy.asarray(input_, dtype='float64'))
++                            numpy.asarray(input_, dtype='float64'),
++                            optimize=False)
+     
+     expected_output = einsummed + b
+     
+-- 
+2.11.0
+


### PR DESCRIPTION
The previous PR went green without testing against numpy 1.14.0. This patch fixes a test failure.