### PR TITLE
Fix incorrect version pin of msgpack-numpy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record=record.txt
   skip: True  # [not x86_64]
 
@@ -48,8 +48,8 @@ requirements:
     - dill >=0.2.6,<0.3.0
     - termcolor >=1.1.0,<1.2.0
     - pathlib >=1.0.0,<2.0.0  # [py27]
-    - msgpack-numpy ==0.4.1
-    - msgpack-python >=0.4.8,<0.5.0
+    - msgpack-numpy 
+    - msgpack-python >=0.5.0,<0.6.0
 
 test:
   requires:


### PR DESCRIPTION
`msgpack-python` needs to be >=0.5.0. Fixing.
