### PR TITLE
Fix version lock on cytoolz

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,14 +15,16 @@ source:
 
 build:
   number: 3
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   skip: True  # [not x86_64]
 
 requirements:
   build:
+    - pip
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
+    - pip
     - msinttypes  # [win and py27]
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 
 build:
-  number: 2
+  number: 3
   script: python setup.py install --single-version-externally-managed --record=record.txt
   skip: True  # [not x86_64]
 
@@ -41,7 +41,7 @@ requirements:
     - cymem >=1.30,<1.32
     - preshed >=1.0.0,<2.0.0
     - tqdm >=4.10.0,<5.0.0
-    - cytoolz >=0.8,<0.9
+    - cytoolz >=0.9,<0.10
     - plac >=0.9.6,<1.0.0
     - six >=1.10.0,<2.0.0
     - wrapt >=1.10.10,<2.0.0


### PR DESCRIPTION
We've been trying to fix a problem in spaCy where if you do `conda install -c conda-forge spacy`, it gives you a super old version. The version constraint on cytoolz here might be the problem.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
