### PR TITLE
[v8.x] fix numpy metadata

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -33,6 +33,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -1,11 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -1,11 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -1,11 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -1,11 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -36,6 +36,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 
 call :start_group "Configuring conda"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,11 @@ package:
 source:
   url: https://pypi.org/packages/source/t/thinc/thinc-{{ version }}.tar.gz
   sha256: 3e8ef69eac89a601e11d47fc9e43d26ffe7ef682dcf667c94ff35ff690549aeb
+  patches:
+    - patches/0001-fix-numpy-metadata.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -46,6 +48,7 @@ requirements:
 
 test:
   requires:
+    - pip
     - hypothesis
     - pytest <8
     - mock
@@ -54,9 +57,9 @@ test:
     - thinc
     - thinc.api
     - thinc.extra
-
   commands:
     - python -m pytest --tb=native --pyargs thinc  # [not ppc64le]
+    - pip check
 
 about:
   home: https://github.com/explosion/thinc/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/t/thinc/thinc-{{ version }}.tar.gz
-  sha256: 3e8ef69eac89a601e11d47fc9e43d26ffe7ef682dcf667c94ff35ff690549aeb
+  url: https://github.com/explosion/thinc/archive/refs/tags/release-v{{ version }}.tar.gz
+  sha256: d72e1b41bdf5e1e8b7b9ac939ea16b4cb6685a790117fa3e99d327bd50bd5aa6
   patches:
     - patches/0001-fix-numpy-metadata.patch
 

--- a/recipe/patches/0001-fix-numpy-metadata.patch
+++ b/recipe/patches/0001-fix-numpy-metadata.patch
@@ -1,0 +1,47 @@
+From a82f5c4721153ff20aa349c8e3b7ddce65ff6bde Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Tue, 3 Dec 2024 06:25:30 +1100
+Subject: [PATCH] fix numpy metadata
+
+---
+ pyproject.toml | 3 +--
+ setup.cfg      | 5 ++---
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index b8277d23..fc0217af 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -6,8 +6,7 @@ requires = [
+     "cymem>=2.0.2,<2.1.0",
+     "preshed>=3.0.2,<3.1.0",
+     "blis>=1.0.0,<1.1.0",
+-    "numpy>=2.0.0,<2.1.0; python_version < '3.9'",
+-    "numpy>=2.0.0,<2.1.0; python_version >= '3.9'",
++    "numpy",
+ ]
+ build-backend = "setuptools.build_meta"
+ 
+diff --git a/setup.cfg b/setup.cfg
+index 72e17269..d7ad158b 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -32,7 +32,7 @@ include_package_data = true
+ python_requires = >=3.6
+ setup_requires =
+     cython>=0.25,<3.0
+-    numpy>=2.0.1,<2.1.0
++    numpy
+     # We also need our Cython packages here to compile against 
+     cymem>=2.0.2,<2.1.0
+     preshed>=3.0.2,<3.1.0
+@@ -50,8 +50,7 @@ install_requires =
+     confection>=0.0.1,<1.0.0
+     # Third-party dependencies
+     setuptools
+-    numpy>=2.0.0,<2.1.0; python_version < "3.9"
+-    numpy>=2.0.0,<2.1.0; python_version >= "3.9"
++    numpy
+     pydantic>=1.7.4,!=1.8,!=1.8.1,<3.0.0
+     packaging>=20.0
+     # Backports of modern Python features


### PR DESCRIPTION
This is based on a misunderstanding how numpy works, and messes up `pip check` everywhere else (e.g. when running in an environment with numpy 2.1, which is fully compatible).